### PR TITLE
Support for network type added

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ import (
 	"eth2-crawler/crawler"
 	"eth2-crawler/graph"
 	"eth2-crawler/graph/generated"
-	ipResolver "eth2-crawler/resolver"
+	"eth2-crawler/resolver/ipdata"
 	mongoStore "eth2-crawler/store/mongo"
 	"eth2-crawler/utils/config"
 	"eth2-crawler/utils/server"
@@ -37,7 +37,10 @@ func main() {
 		log.Fatalf("error Initializing the peer store: %s", err.Error())
 	}
 
-	resolverService := ipResolver.New(cfg.Resolver.APIKey, time.Duration(cfg.Resolver.Timeout)*time.Second)
+	resolverService, err := ipdata.New(cfg.Resolver.APIKey, time.Duration(cfg.Resolver.Timeout)*time.Second)
+	if err != nil {
+		log.Fatalf("error Initializing the ip resolver: %s", err.Error())
+	}
 
 	// TODO collect config from a config files or from command args and pass to Start()
 	go crawler.Start(peerStore, resolverService)

--- a/crawler/crawl/crawl.go
+++ b/crawler/crawl/crawl.go
@@ -157,10 +157,9 @@ func (c *crawler) savePeerInformation(ctx context.Context, peer *models.Peer) {
 			"error":   err,
 			"ip_addr": peer.IP,
 		})
-		return
+	} else {
+		peer.SetGeoLocation(geoLoc)
 	}
-
-	peer.SetGeoLocation(geoLoc)
 
 	err = c.peerStore.Create(ctx, peer)
 	if err != nil {
@@ -177,9 +176,9 @@ func (c *crawler) updatePeerInformation(ctx context.Context, new *models.Peer, o
 				"error":   err,
 				"ip_addr": new.IP,
 			})
-			return
+		} else {
+			new.SetGeoLocation(geoLoc)
 		}
-		new.SetGeoLocation(geoLoc)
 	} else {
 		new.SetGeoLocation(old.GeoLocation)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/99designs/gqlgen v0.13.0
 	github.com/ethereum/go-ethereum v1.10.6
+	github.com/ipdata/go v0.7.2
 	github.com/libp2p/go-libp2p v0.14.4
 	github.com/libp2p/go-libp2p-core v0.8.6
 	github.com/libp2p/go-libp2p-noise v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,8 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
+github.com/ipdata/go v0.7.2 h1:Ly+xBqMSUF1kmd6UK12wW0CGL7a/JDrbOcV8tUd+120=
+github.com/ipdata/go v0.7.2/go.mod h1:JKi7SLHzLMj6fbFwUDZLqY2QP1BMGjktwgb/ALjvTdw=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -14,17 +14,6 @@ import (
 )
 
 func (r *queryResolver) AggregateByAgentName(ctx context.Context) ([]*model.AggregateData, error) {
-	// Sending dummy data
-	// return []*model.AggregateData{
-	// 	&model.AggregateData{Name: "Cortex", Count: 356},
-	// 	&model.AggregateData{Name: "Lighthouse", Count: 250},
-	// 	&model.AggregateData{Name: "Lodestar", Count: 211},
-	// 	&model.AggregateData{Name: "Nimbus", Count: 189},
-	// 	&model.AggregateData{Name: "Prysm", Count: 115},
-	// 	&model.AggregateData{Name: "Teku", Count: 112},
-	// 	&model.AggregateData{Name: "Trinity", Count: 89},
-	// }, nil
-
 	aggregateData, err := r.peerStore.AggregateByAgentName(ctx)
 	if err != nil {
 		return nil, err
@@ -41,21 +30,6 @@ func (r *queryResolver) AggregateByAgentName(ctx context.Context) ([]*model.Aggr
 }
 
 func (r *queryResolver) AggregateByCountry(ctx context.Context) ([]*model.AggregateData, error) {
-	// Sending dummy data
-	// return []*model.AggregateData{
-	// 	&model.AggregateData{Name: "United States", Count: 558},
-	// 	&model.AggregateData{Name: "Germany", Count: 429},
-	// 	&model.AggregateData{Name: "China", Count: 412},
-	// 	&model.AggregateData{Name: "France", Count: 378},
-	// 	&model.AggregateData{Name: "Singapore", Count: 349},
-	// 	&model.AggregateData{Name: "United Kingdom", Count: 187},
-	// 	&model.AggregateData{Name: "Canada", Count: 173},
-	// 	&model.AggregateData{Name: "Netherlands", Count: 113},
-	// 	&model.AggregateData{Name: "Japan", Count: 104},
-	// 	&model.AggregateData{Name: "Finland", Count: 23},
-	// 	&model.AggregateData{Name: "South Korea", Count: 12},
-	// }, nil
-
 	aggregateData, err := r.peerStore.AggregateByCountry(ctx)
 	if err != nil {
 		return nil, err
@@ -72,13 +46,6 @@ func (r *queryResolver) AggregateByCountry(ctx context.Context) ([]*model.Aggreg
 }
 
 func (r *queryResolver) AggregateByOperatingSystem(ctx context.Context) ([]*model.AggregateData, error) {
-	// Sending dummy data
-	// return []*model.AggregateData{
-	// 	&model.AggregateData{Name: "Linux", Count: 1023},
-	// 	&model.AggregateData{Name: "Windows", Count: 294},
-	// 	&model.AggregateData{Name: "MacOS", Count: 138},
-	// }, nil
-
 	aggregateData, err := r.peerStore.AggregateByOperatingSystem(ctx)
 	if err != nil {
 		return nil, err
@@ -95,12 +62,19 @@ func (r *queryResolver) AggregateByOperatingSystem(ctx context.Context) ([]*mode
 }
 
 func (r *queryResolver) AggregateByNetwork(ctx context.Context) ([]*model.AggregateData, error) {
-	// Sending dummy data
-	return []*model.AggregateData{
-		&model.AggregateData{Name: "Hosted", Count: 1002},
-		&model.AggregateData{Name: "Residential", Count: 445},
-		&model.AggregateData{Name: "Business", Count: 76},
-	}, nil
+	aggregateData, err := r.peerStore.AggregateByNetworkType(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []*model.AggregateData{}
+	for i := range aggregateData {
+		result = append(result, &model.AggregateData{
+			Name:  aggregateData[i].Name,
+			Count: aggregateData[i].Count,
+		})
+	}
+	return result, nil
 }
 
 // Query returns generated.QueryResolver implementation.

--- a/models/peer.go
+++ b/models/peer.go
@@ -27,15 +27,36 @@ type UserAgent struct {
 	OS      string `json:"os" bson:"os"`
 }
 
+// UsageType defines the ASN usage type
+type UsageType string
+
+const (
+	UsageTypeNil         UsageType = ""
+	UsageTypeHosting     UsageType = "hosting"
+	UsageTypeResidential UsageType = "residential"
+	UsageTypeBusiness    UsageType = "business"
+	UsageTypeEducation   UsageType = "education"
+	UsageTypeGovernment  UsageType = "government"
+	UsageTypeMilitary    UsageType = "military"
+)
+
+// ASN holds the Autonomous system details
+type ASN struct {
+	ID     string    `json:"id" bson:"id"`
+	Name   string    `json:"name" bson:"name"`
+	Domain string    `json:"domain" bson:"domain"`
+	Route  string    `json:"route" bson:"route"`
+	Type   UsageType `json:"type" bson:"type"`
+}
+
 // GeoLocation holds peer's geo location related info
 type GeoLocation struct {
-	ISP          string `json:"isp" bson:"isp"`
-	Organization string `json:"organization" bson:"organization"`
-	Country      string `json:"country_name" bson:"country"`
-	State        string `json:"state" bson:"state"`
-	City         string `json:"city" bson:"city"`
-	Latitude     string `json:"latitude" bson:"latitude"`
-	Longitude    string `json:"longitude" bson:"longitude"`
+	ASN       ASN     `json:"asn" nson:"asn"`
+	Country   string  `json:"country_name" bson:"country"`
+	State     string  `json:"state" bson:"state"`
+	City      string  `json:"city" bson:"city"`
+	Latitude  float64 `json:"latitude" bson:"latitude"`
+	Longitude float64 `json:"longitude" bson:"longitude"`
 }
 
 // Peer holds all information of a eth2 peer

--- a/resolver/ipdata/ipdata.go
+++ b/resolver/ipdata/ipdata.go
@@ -1,0 +1,75 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Package ipdata implements the ip resolver using ipdata APIs
+package ipdata
+
+import (
+	"context"
+	"eth2-crawler/models"
+	"eth2-crawler/resolver"
+	"time"
+
+	ipdata "github.com/ipdata/go"
+)
+
+type client struct {
+	ipdataClient   ipdata.Client
+	defaultTimeout time.Duration
+}
+
+func New(apiKey string, defaultTimeout time.Duration) (resolver.Provider, error) {
+	ipdataClient, err := ipdata.NewClient(apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{
+		ipdataClient:   ipdataClient,
+		defaultTimeout: defaultTimeout,
+	}, nil
+}
+
+func (c *client) GetGeoLocation(ctx context.Context, ipAddr string) (*models.GeoLocation, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.defaultTimeout)
+	defer cancel()
+
+	data, err := c.ipdataClient.LookupWithContext(ctx, ipAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	var asnType models.UsageType
+	switch data.ASN.Type {
+	case "hosting":
+		asnType = models.UsageTypeHosting
+	case "isp":
+		asnType = models.UsageTypeResidential
+	case "business":
+		asnType = models.UsageTypeBusiness
+	case "edu":
+		asnType = models.UsageTypeEducation
+	case "gov":
+		asnType = models.UsageTypeGovernment
+	case "mil":
+		asnType = models.UsageTypeMilitary
+	default:
+		asnType = models.UsageTypeNil
+	}
+
+	geoLoc := &models.GeoLocation{
+		ASN: models.ASN{
+			ID:     data.ASN.ASN,
+			Name:   data.ASN.Name,
+			Domain: data.ASN.Domain,
+			Route:  data.ASN.Route,
+			Type:   asnType,
+		},
+		Country:   data.CountryName,
+		State:     data.Region,
+		City:      data.City,
+		Latitude:  data.Latitude,
+		Longitude: data.Longitude,
+	}
+	return geoLoc, nil
+}

--- a/resolver/ipgeolocation/ipgeolocation.go
+++ b/resolver/ipgeolocation/ipgeolocation.go
@@ -1,0 +1,90 @@
+// Copyright 2021 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Package ipgeolocation implements the ip resolver using ipgeolocation APIs
+package ipgeolocation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"eth2-crawler/models"
+	"eth2-crawler/resolver"
+)
+
+const (
+	url = "https://api.ipgeolocation.io/ipgeo"
+)
+
+type client struct {
+	httpClient *http.Client
+	apiKey     string
+}
+
+type geoInformation struct {
+	ISP          string `json:"isp"`
+	Organization string `json:"organization"`
+	Country      string `json:"country_name"`
+	State        string `json:"state_prov"`
+	City         string `json:"city"`
+	Latitude     string `json:"latitude"`
+	Longitude    string `json:"longitude"`
+}
+
+func New(apiKey string, defaultTimeout time.Duration) resolver.Provider {
+	return &client{
+		httpClient: &http.Client{Timeout: defaultTimeout},
+		apiKey:     apiKey,
+	}
+}
+
+func (c *client) GetGeoLocation(ctx context.Context, ipAddr string) (*models.GeoLocation, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	q.Add("apiKey", c.apiKey)
+	q.Add("ip", ipAddr)
+	req.URL.RawQuery = q.Encode()
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// nolint
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read response body")
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("invalid status code returned. statusCode::%d response::%s", res.StatusCode, string(resBody))
+	}
+
+	result := &geoInformation{}
+	err = json.Unmarshal(resBody, result)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal body. error::%w", err)
+	}
+
+	lat, _ := strconv.ParseFloat(result.Latitude, 64)
+	long, _ := strconv.ParseFloat(result.Longitude, 64)
+
+	geoLoc := &models.GeoLocation{
+		Country:   result.Country,
+		State:     result.State,
+		City:      result.City,
+		Latitude:  lat,
+		Longitude: long,
+	}
+	return geoLoc, nil
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -6,86 +6,10 @@ package resolver
 
 import (
 	"context"
-	"encoding/json"
-	"eth2-crawler/models"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"time"
-)
 
-const (
-	url = "https://api.ipgeolocation.io/ipgeo"
+	"eth2-crawler/models"
 )
 
 type Provider interface {
 	GetGeoLocation(ctx context.Context, ipAddr string) (*models.GeoLocation, error)
-}
-
-type client struct {
-	httpClient *http.Client
-	apiKey     string
-}
-
-type geoInformation struct {
-	ISP          string `json:"isp"`
-	Organization string `json:"organization"`
-	Country      string `json:"country_name"`
-	State        string `json:"state_prov"`
-	City         string `json:"city"`
-	Latitude     string `json:"latitude"`
-	Longitude    string `json:"longitude"`
-}
-
-func New(apiKey string, defaultTimeout time.Duration) Provider {
-	return &client{
-		httpClient: &http.Client{Timeout: defaultTimeout},
-		apiKey:     apiKey,
-	}
-}
-
-func (c *client) GetGeoLocation(ctx context.Context, ipAddr string) (*models.GeoLocation, error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	q := req.URL.Query()
-	q.Add("apiKey", c.apiKey)
-	q.Add("ip", ipAddr)
-	req.URL.RawQuery = q.Encode()
-
-	res, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	// nolint
-	defer res.Body.Close()
-	resBody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read response body")
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("invalid status code returned. statusCode::%d response::%s", res.StatusCode, string(resBody))
-	}
-
-	result := &geoInformation{}
-	err = json.Unmarshal(resBody, result)
-	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal body. error::%w", err)
-	}
-
-	geoLoc := &models.GeoLocation{
-		ISP:          result.ISP,
-		Organization: result.Organization,
-		Country:      result.Country,
-		State:        result.State,
-		City:         result.City,
-		Latitude:     result.Latitude,
-		Longitude:    result.Longitude,
-	}
-
-	return geoLoc, nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -21,4 +21,5 @@ type Provider interface {
 	AggregateByAgentName(ctx context.Context) ([]*models.AggregateData, error)
 	AggregateByOperatingSystem(ctx context.Context) ([]*models.AggregateData, error)
 	AggregateByCountry(ctx context.Context) ([]*models.AggregateData, error)
+	AggregateByNetworkType(ctx context.Context) ([]*models.AggregateData, error)
 }


### PR DESCRIPTION
## Description
This PR adds network details of the node to database and expose the information. using graphQL query.

## Changes
- Integrated with ipdata APIs
- GraphQL query added to get aggregate data based on network type(Hosting/Business/Residential etc)
- Silently ignore if crawler fails to get IP related information

Closes: #40
